### PR TITLE
Implement the OpenAI responses API for better GPT-5 compatibility

### DIFF
--- a/app/Http/Controllers/AiConvController.php
+++ b/app/Http/Controllers/AiConvController.php
@@ -244,7 +244,6 @@ class AiConvController extends Controller
 
     public function updateMessage(Request $request, $slug) {
         
-        Log::info("!!!!", $request->all());
         $validatedData = $request->validate([
             'message_id' => 'required|string',
             'content' => 'required|string|max:10000',
@@ -278,14 +277,12 @@ class AiConvController extends Controller
 
         $auxiliaries = [];
         if (isset($validatedData['auxiliaries'])) {
+            // drop previous auxiliaries and recreate them
+            $message->auxiliaries()->delete();
             foreach($validatedData['auxiliaries'] as $auxiliary) {
-                if (!isset($auxiliary['id'])) {
-                    continue;
-                }
-                $aux = $message->auxilaries->where('id', $auxiliary['id'])->first();
-                $aux->update([
+                $aux = AiConvMsgAux::create([
                     'msg_id' => $message->id,
-                    'user_id' => $user->id,
+                    'user_id' => $message->user_id,
                     'iv' => $auxiliary['iv'],
                     'tag' => $auxiliary['tag'],
                     'type' => $auxiliary['type'],
@@ -299,6 +296,7 @@ class AiConvController extends Controller
         $messageData = $message->toArray();
         $messageData['created_at'] = $message->created_at->format('Y-m-d+H:i');
         $messageData['updated_at'] = $message->updated_at->format('Y-m-d+H:i');
+        $messageData['auxiliaries'] = $auxiliaries;
 
         return response()->json([
             'success' => true,

--- a/app/Http/Controllers/AiConvController.php
+++ b/app/Http/Controllers/AiConvController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\AiConv;
 use App\Models\AiConvMsg;
+use App\Models\AiConvMsgAux;
 use App\Models\User;
 
 use Illuminate\Http\JsonResponse;
@@ -152,23 +153,21 @@ class AiConvController extends Controller
                 'completion' => $message->completion,
                 'created_at' => $message->created_at->format('Y-m-d+H:i'),
                 'updated_at' => $message->updated_at->format('Y-m-d+H:i'),
-            ];
-
+                'auxiliaries' => $message->auxiliaries ? $message->auxiliaries->toArray() : [],
+            ]; 
             array_push($messagesData, $msgData);
         }
         return $messagesData;
 
     }
 
-
     /// 1. find the conv on DB
     /// 2. check the membership validation
     /// 3. assign an id to the message
-    /// 4. create message object
+    /// 4. create message object and any auxiliary data
     /// 5. qeue message for broadcasting
     /// 6. send response to the sender
     public function sendMessage(Request $request, $slug) {
-
         $validatedData = $request->validate([
             'isAi' => 'required|boolean',
             'threadID' => 'required|integer|min:0',
@@ -177,8 +176,12 @@ class AiConvController extends Controller
             'tag' => 'required|string',
             'model' => 'string',
             'completion' => 'required|boolean',
+            'auxiliaries' => 'nullable|array',
+            'auxiliaries.*.type' => 'required|string',
+            'auxiliaries.*.iv' => 'required|string',
+            'auxiliaries.*.tag' => 'required|string',
+            'auxiliaries.*.content' => 'required|string',
         ]);
-
 
         $conv = AiConv::where('slug', $slug)->firstOrFail();
         if ($conv->user_id !== Auth::id()) {
@@ -202,6 +205,23 @@ class AiConvController extends Controller
             'completion' => $validatedData['completion'],
         ]);
 
+        // add any auxiliary data
+        $auxiliaries = [];
+        if (isset($validatedData['auxiliaries'])) {
+            foreach($validatedData['auxiliaries'] as $auxiliary) {
+                $aux = AiConvMsgAux::create([
+                    'msg_id' => $message->id,
+                    'user_id' => $user->id,
+                    'iv' => $auxiliary['iv'],
+                    'tag' => $auxiliary['tag'],
+                    'type' => $auxiliary['type'],
+                    'content' => $auxiliary['content'],
+                ]);
+                $auxiliaries[] = $aux->toArray();
+            }
+            
+        }
+
         // add author data + creation and update dates to response data.
         $messageData = $message->toArray();
         $messageData['author'] = [
@@ -211,7 +231,7 @@ class AiConvController extends Controller
         ];
         $messageData['created_at'] = $message->created_at->format('Y-m-d+H:i');
         $messageData['updated_at'] = $message->updated_at->format('Y-m-d+H:i');
-
+        $messageData['auxiliaries'] =  $auxiliaries;
 
         return response()->json([
             'success' => true,
@@ -224,6 +244,7 @@ class AiConvController extends Controller
 
     public function updateMessage(Request $request, $slug) {
         
+        Log::info("!!!!", $request->all());
         $validatedData = $request->validate([
             'message_id' => 'required|string',
             'content' => 'required|string|max:10000',
@@ -231,6 +252,12 @@ class AiConvController extends Controller
             'tag' => 'required|string',
             'model' => 'nullable|string',
             'completion' => 'required|boolean',
+            'auxiliaries' => 'nullable|array',
+            'auxiliaries.*.id' => 'nullable|string',
+            'auxiliaries.*.type' => 'required|string',
+            'auxiliaries.*.iv' => 'required|string',
+            'auxiliaries.*.tag' => 'required|string',
+            'auxiliaries.*.content' => 'required|string',
         ]);     
 
         $conv = AiConv::where('slug', $slug)->firstOrFail();
@@ -246,8 +273,28 @@ class AiConvController extends Controller
             'iv' => $validatedData['iv'],
             'tag' => $validatedData['tag'],
             'model' => $validatedData['model'],
-            'completion' => $validatedData['completion']
+            'completion' => $validatedData['completion'],
         ]);
+
+        $auxiliaries = [];
+        if (isset($validatedData['auxiliaries'])) {
+            foreach($validatedData['auxiliaries'] as $auxiliary) {
+                if (!isset($auxiliary['id'])) {
+                    continue;
+                }
+                $aux = $message->auxilaries->where('id', $auxiliary['id'])->first();
+                $aux->update([
+                    'msg_id' => $message->id,
+                    'user_id' => $user->id,
+                    'iv' => $auxiliary['iv'],
+                    'tag' => $auxiliary['tag'],
+                    'type' => $auxiliary['type'],
+                    'content' => $auxiliary['content'],
+                ]);
+                $auxiliaries[] = $aux->toArray();
+            }
+            
+        }
 
         $messageData = $message->toArray();
         $messageData['created_at'] = $message->created_at->format('Y-m-d+H:i');

--- a/app/Http/Controllers/StreamController.php
+++ b/app/Http/Controllers/StreamController.php
@@ -179,7 +179,6 @@ class StreamController extends Controller
                 //Log::info('google chunk detected');
             }
 
-        
             // Skip non-JSON or empty chunks
             $chunks = explode("data: ", $data);
             foreach ($chunks as $chunk) {

--- a/app/Http/Controllers/StreamController.php
+++ b/app/Http/Controllers/StreamController.php
@@ -99,7 +99,6 @@ class StreamController extends Controller
      */
     public function handleAiConnectionRequest(Request $request)
     {
-        //error_log(print_r($request, true));
         //validate payload
         $validatedData = $request->validate([
             'payload.model' => 'required|string',
@@ -192,7 +191,6 @@ class StreamController extends Controller
                 
                 // Format the chunk
                 $formatted = $provider->formatStreamChunk($chunk);
-                // Log::info('Formatted Chunk:' . json_encode($formatted));
 
                 // Record usage if available
                 if ($formatted['usage']) {

--- a/app/Http/Controllers/StreamController.php
+++ b/app/Http/Controllers/StreamController.php
@@ -56,6 +56,7 @@ class StreamController extends Controller
                 'payload.messages.*.role' => 'required|string',
                 'payload.messages.*.content' => 'required|array',
                 'payload.messages.*.content.text' => 'required|string',
+                'payload.messages.*.content.previousMessageId' => 'nullable|string',
             ]);
         } catch (ValidationException $e) {
             // Return detailed validation error response
@@ -98,6 +99,7 @@ class StreamController extends Controller
      */
     public function handleAiConnectionRequest(Request $request)
     {
+        //error_log(print_r($request, true));
         //validate payload
         $validatedData = $request->validate([
             'payload.model' => 'required|string',
@@ -106,6 +108,7 @@ class StreamController extends Controller
             'payload.messages.*.role' => 'required|string',
             'payload.messages.*.content' => 'required|array',
             'payload.messages.*.content.text' => 'required|string',
+            'payload.messages.*.content.previousMessageId' => 'nullable|string',
 
             'broadcast' => 'required|boolean',
             'isUpdate' => 'nullable|boolean',

--- a/app/Http/Controllers/StreamController.php
+++ b/app/Http/Controllers/StreamController.php
@@ -56,7 +56,7 @@ class StreamController extends Controller
                 'payload.messages.*.role' => 'required|string',
                 'payload.messages.*.content' => 'required|array',
                 'payload.messages.*.content.text' => 'required|string',
-                'payload.messages.*.content.previousMessageId' => 'nullable|string',
+                'payload.messages.*.content.providerMessageId' => 'nullable|string',
             ]);
         } catch (ValidationException $e) {
             // Return detailed validation error response
@@ -107,7 +107,7 @@ class StreamController extends Controller
             'payload.messages.*.role' => 'required|string',
             'payload.messages.*.content' => 'required|array',
             'payload.messages.*.content.text' => 'required|string',
-            'payload.messages.*.content.previousMessageId' => 'nullable|string',
+            'payload.messages.*.content.providerMessageId' => 'nullable|string',
 
             'broadcast' => 'required|boolean',
             'isUpdate' => 'nullable|boolean',

--- a/app/Http/Controllers/StreamController.php
+++ b/app/Http/Controllers/StreamController.php
@@ -56,7 +56,6 @@ class StreamController extends Controller
                 'payload.messages.*.role' => 'required|string',
                 'payload.messages.*.content' => 'required|array',
                 'payload.messages.*.content.text' => 'required|string',
-                'payload.messages.*.reasoning' => 'nullable|string',
             ]);
         } catch (ValidationException $e) {
             // Return detailed validation error response

--- a/app/Models/AiConvMsg.php
+++ b/app/Models/AiConvMsg.php
@@ -31,4 +31,10 @@ class AiConvMsg extends Model
         return $this->belongsTo(User::class);
     }
 
+    // Define the relationship with AiConvMsg
+    public function auxiliaries()
+    {
+        return $this->hasMany(AiConvMsgAux::class, 'msg_id');
+    }
+
 }

--- a/app/Models/AiConvMsgAux.php
+++ b/app/Models/AiConvMsgAux.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class AiConvMsgAux extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'msg_id',
+        'user_id',
+        'type',
+        'iv',
+        'tag',
+        'content',
+    ];
+
+    public function user(){
+        return $this->belongsTo(User::class);
+    }
+
+    // Define the relationship with AiConv
+    public function message()
+    {
+        return $this->belongsTo(AiConvMsg::class, 'msg_id');
+    }
+
+}

--- a/app/Services/AI/AIProviderFactory.php
+++ b/app/Services/AI/AIProviderFactory.php
@@ -4,6 +4,7 @@ namespace App\Services\AI;
 
 use App\Services\AI\Interfaces\AIModelProviderInterface;
 use App\Services\AI\Providers\OpenAIProvider;
+use App\Services\AI\Providers\OpenAIResponsesProvider;
 use App\Services\AI\Providers\GWDGProvider;
 use App\Services\AI\Providers\GoogleProvider;
 use App\Services\AI\Providers\OllamaProvider;
@@ -47,6 +48,8 @@ class AIProviderFactory
         switch ($providerId) {
             case 'openai':
                 return new OpenAIProvider($this->config['providers']['openai']);
+            case 'openai-responses':
+                return new OpenAIResponsesProvider($this->config['providers']['openai-responses']);
             case 'gwdg':
                 return new GWDGProvider($this->config['providers']['gwdg']);
             case 'google':

--- a/app/Services/AI/Providers/OpenAIResponsesProvider.php
+++ b/app/Services/AI/Providers/OpenAIResponsesProvider.php
@@ -1,0 +1,323 @@
+<?php
+
+namespace App\Services\AI\Providers;
+
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Http;
+
+class OpenAIResponsesProvider extends BaseAIModelProvider
+{
+
+    public function mapMessages(array $messages): array
+    {
+        $mapped = [];
+
+        foreach ($messages as $message) {
+            $mapped[] = [
+                // change: map "system" -> "developer"
+                'role' => ($message['role'] === 'system') ? 'developer' : $message['role'],
+                'content' => $message['content'],
+            ];
+        }
+
+        return $mapped;
+    }
+    /**
+     * Format the raw payload for OpenAI Responses API
+     *
+     * @param array $rawPayload
+     * @return array
+     */
+    public function formatPayload(array $rawPayload): array
+    {
+        $messages = $rawPayload['messages'];
+        $modelId = $rawPayload['model'];
+        
+        // Handle special cases for specific models
+        $messages = $this->mapMessages($messages);
+
+        // Convert messages into the Responses API "input" shape
+        $input = [];
+        $previousMessageId = '';
+        foreach ($messages as $message) {
+            $contentText = $message['content']['text'] ?? '';
+            $previousMessageId = $message['content']['previousMessageId'] ?? '';
+            $input[] = [
+                'role' => $message['role'],
+                'content' => $contentText
+            ];
+            
+        }
+
+        // Build payload for Responses endpoint
+        $payload = [
+            'model' => $modelId,
+            'input' => $input,
+            // keep stream flag; streaming handled by makeStreamingRequest
+            //'stream' => !empty($rawPayload['stream']) && $this->supportsStreaming($modelId),
+            'reasoning' => ['effort' => 'low']
+        ];
+
+       
+
+        // include previous_response_id if provided (Responses API uses previous_response to continue reasoning)
+        if (!empty($previousMessageId)) {
+            $payload['previous_response_id'] = $previousMessageId;
+        }
+
+        //error_log(print_r($payload, true));
+
+        return $payload;
+    }
+
+    /**
+     * Format the complete response from Responses API
+     *
+     * @param mixed $response
+     * @return array
+     */
+    public function formatResponse($response): array
+    {
+        
+        $responseContent = $response->getContent();
+        $jsonContent = json_decode($responseContent, true);
+
+        //error_log(print_r($jsonContent, true));
+
+        // Extract text from the Responses "output" structure
+        $texts = [];
+        
+        if (!empty($jsonContent['output']) && is_array($jsonContent['output'])) {
+            foreach ($jsonContent['output'] as $outputItem) {
+                
+                
+                if (!empty($outputItem['content']) && is_array($outputItem['content'])) {
+                    if ($outputItem['type'] == "message") {
+                        foreach ($outputItem['content'] as $c) {
+                            if (is_string($c)) {
+                                $texts[] = $c;
+                            } elseif (!empty($c['text'])) {
+                                $texts[] = $c['text'];
+                            }
+                        }
+                    }
+                }
+            
+            }
+        }
+
+        $contentText = implode('', $texts);
+
+        return [
+            'content' => [
+                'text' => $contentText,
+                'previousMessageId' => $jsonContent['id'],
+            ],
+            'usage' => $this->extractUsage($jsonContent),
+            // keep the whole raw response optionally for debugging/traceability
+            
+        ];
+    }
+
+    /**
+     * Format a single chunk from a streaming Responses API stream
+     *
+     * @param string $chunk
+     * @return array
+     */
+    public function formatStreamChunk(string $chunk): array
+    {
+        $jsonChunk = json_decode($chunk, true);
+        $content = '';
+        $isDone = false;
+        $usage = null;
+
+        if (empty($jsonChunk) || !is_array($jsonChunk)) {
+            return [
+                'content' => ['text' => ''],
+                'isDone' => false,
+                'usage' => null,
+                'raw' => $chunk,
+            ];
+        }
+
+        // The Responses streaming events often include a "type" field.
+        // Completed event:
+        if (isset($jsonChunk['type']) && in_array($jsonChunk['type'], ['response.completed', 'response.refreshed'], true)) {
+            $isDone = true;
+        }
+
+        // Delta-style updates may include output/content deltas
+        // Try to collect any text we find in a few common locations
+        if (!empty($jsonChunk['delta'])) {
+            // delta may mirror the output structure
+            $delta = $jsonChunk['delta'];
+            if (!empty($delta['content']) && is_array($delta['content'])) {
+                foreach ($delta['content'] as $c) {
+                    if (is_string($c)) {
+                        $content .= $c;
+                    } elseif (!empty($c['text'])) {
+                        $content .= $c['text'];
+                    }
+                }
+            } elseif (!empty($delta['text'])) {
+                $content .= $delta['text'];
+            }
+        }
+
+        // Some stream chunks may include an 'output' directly
+        if (empty($content) && !empty($jsonChunk['output']) && is_array($jsonChunk['output'])) {
+            foreach ($jsonChunk['output'] as $outputItem) {
+                if (!empty($outputItem['content']) && is_array($outputItem['content'])) {
+                    foreach ($outputItem['content'] as $c) {
+                        if (is_string($c)) {
+                            $content .= $c;
+                        } elseif (!empty($c['text'])) {
+                            $content .= $c['text'];
+                        }
+                    }
+                }
+            }
+        }
+
+        // Extract usage data if available
+        if (!empty($jsonChunk['usage'])) {
+            $usage = $this->extractUsage($jsonChunk);
+        } elseif (!empty($jsonChunk['metadata']['usage'])) {
+            $usage = $this->extractUsage($jsonChunk['metadata']['usage']);
+        }
+
+        return [
+            'content' => [
+                'text' => $content,
+            ],
+            'isDone' => $isDone,
+            'usage' => $usage,
+            'raw' => $jsonChunk,
+        ];
+    }
+
+    /**
+     * Extract usage information from Responses API output
+     *
+     * @param array $data
+     * @return array|null
+     */
+    protected function extractUsage(array $data): ?array
+    {
+        // Responses API usage may appear under top-level 'usage' or nested structures.
+        if (empty($data)) {
+            return null;
+        }
+
+        if (!empty($data['usage']) && is_array($data['usage'])) {
+            $usage = $data['usage'];
+            return [
+                'prompt_tokens' => $usage['prompt_tokens'] ?? ($usage['input_tokens'] ?? null),
+                'completion_tokens' => $usage['completion_tokens'] ?? ($usage['output_tokens'] ?? null),
+            ];
+        }
+
+        // Fallback: some events may include usage-like fields under metadata
+        if (!empty($data['metadata']) && !empty($data['metadata']['usage'])) {
+            $usage = $data['metadata']['usage'];
+            return [
+                'prompt_tokens' => $usage['prompt_tokens'] ?? null,
+                'completion_tokens' => $usage['completion_tokens'] ?? null,
+            ];
+        }
+
+        return null;
+    }
+
+    /**
+     * Make a non-streaming request to the OpenAI API
+     *
+     * @param array $payload The formatted payload
+     * @return mixed The response
+     */
+    public function makeNonStreamingRequest(array $payload)
+    {
+        // Ensure stream is set to false
+        $payload['stream'] = false;
+
+        // Initialize cURL
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $this->config['api_url']);
+
+        // Set common cURL options
+        $this->setCommonCurlOptions($ch, $payload, $this->getHttpHeaders());
+
+        // Execute the request
+        $response = curl_exec($ch);
+        //error_log(print_r($response, true));
+        //error_log(print_r("1", true));
+
+        // Handle errors
+        if (curl_errno($ch)) {
+            $error = 'Error: ' . curl_error($ch);
+            curl_close($ch);
+            return response()->json(['error' => $error], 500);
+        }
+         //error_log(print_r("2", true));
+        curl_close($ch);
+         //error_log(print_r("3", true));
+        return response($response)->header('Content-Type', 'application/json');
+    }
+
+    /**
+     * Make a streaming request to the OpenAI API
+     *
+     * @param array $payload The formatted payload
+     * @param callable $streamCallback Callback for streaming responses
+     * @return void
+     */
+    public function makeStreamingRequest(array $payload, callable $streamCallback)
+    {
+        // Ensure stream is set to true
+        $payload['stream'] = true;
+        // Enable usage reporting
+        $payload['stream_options'] = [
+            'include_usage' => true,
+        ];
+
+        set_time_limit(120);
+
+        // Set headers for SSE
+        header('Content-Type: text/event-stream');
+        header('Cache-Control: no-cache');
+        header('Connection: keep-alive');
+        header('Access-Control-Allow-Origin: *');
+
+        // Initialize cURL
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $this->config['api_url']);
+
+        // Set common cURL options
+        $this->setCommonCurlOptions($ch, $payload, $this->getHttpHeaders(true));
+
+        // Set streaming-specific options
+        $this->setStreamingCurlOptions($ch, $streamCallback);
+
+        // Execute the cURL session
+        curl_exec($ch);
+
+        // Handle errors
+        if (curl_errno($ch)) {
+            $streamCallback('Error: ' . curl_error($ch));
+            if (ob_get_length()) {
+                ob_flush();
+            }
+            flush();
+        }
+
+        curl_close($ch);
+
+        // Flush any remaining data
+        if (ob_get_length()) {
+            ob_flush();
+        }
+        flush();
+    }
+
+}

--- a/app/Services/AI/Providers/OpenAIResponsesProvider.php
+++ b/app/Services/AI/Providers/OpenAIResponsesProvider.php
@@ -64,10 +64,17 @@ class OpenAIResponsesProvider extends BaseAIModelProvider
 
         // add aditional configuration options
         $config = $this->config;
+        $modelConfig = [];
+        foreach ($config['models'] as $conf) {
+            if ($conf['id'] == $modelId) {
+                $modelConfig = $conf;
+                break;
+            }
+        }
 
         // set the reasoning effort
-        if (isset($config[$modelId]['reasoning_effort'])) {
-            $payload['reasoning'] = ['effort' => $config[$modelId]['reasoning_effort']];
+        if (isset($modelConfig['reasoning_effort'])) {
+            $payload['reasoning'] = ['effort' => $modelConfig['reasoning_effort']];
         }
 
         // store message on the server side / or not...

--- a/app/Services/AI/Providers/OpenAIResponsesProvider.php
+++ b/app/Services/AI/Providers/OpenAIResponsesProvider.php
@@ -55,17 +55,29 @@ class OpenAIResponsesProvider extends BaseAIModelProvider
             'input' => $input,
             // keep stream flag; streaming handled by makeStreamingRequest
             //'stream' => !empty($rawPayload['stream']) && $this->supportsStreaming($modelId),
-            'reasoning' => ['effort' => 'low']
+            //'reasoning' => ['effort' => 'low']
         ];
-
-       
 
         // include previous_response_id if provided (Responses API uses previous_response to continue reasoning)
         if (!empty($previousMessageId)) {
             $payload['previous_response_id'] = $previousMessageId;
         }
 
-        //error_log(print_r($payload, true));
+        // add aditional configuration options
+        $config = $this->config;
+        if (isset($config[$modelId]['reasoning_effort'])) {
+            $payload['reasoning'] = ['effort' => $config[$modelId]['reasoning_effort']];
+        }
+
+        if (isset($config['store'])) {
+            $payload['store'] = $config['store'];
+        }
+
+        if (isset($config['encrypt_reasoning_content']) && $config['encrypt_reasoning_content']) {
+            $payload['include'] = ["reasoning.encrypted_content"];
+        }
+
+        error_log(print_r($payload, true));
 
         return $payload;
     }
@@ -114,7 +126,6 @@ class OpenAIResponsesProvider extends BaseAIModelProvider
                 'previousMessageId' => $jsonContent['id'],
             ],
             'usage' => $this->extractUsage($jsonContent),
-            // keep the whole raw response optionally for debugging/traceability
             
         ];
     }

--- a/config/model_providers.php.example
+++ b/config/model_providers.php.example
@@ -9,7 +9,7 @@ return [
     |   This Model is used by default before the user choses their
     |   desired model.
     */
-    'defaultModel' => 'gpt-4o',
+    'defaultModel' => 'gpt-5',
 
     /*
     |--------------------------------------------------------------------------
@@ -61,6 +61,33 @@ return [
                     'id' => 'o1-mini',
                     'label' => 'OpenAI O1 mini',
                     'streamable' => false,
+                ]
+            ]
+        ],
+
+        // GPT-5 models work better with the responses API
+        'openai-responses' => [
+            'id' => 'openai-responses',
+            'active' => true,
+            'api_key' => env('OPENAI_API_KEY', ''),
+            'api_url' => 'https://api.openai.com/v1/responses',
+            'ping_url' => 'https://api.openai.com/v1/models',
+            // set store := false and encrypt_reasoning_content := true to 
+            // ensure reasoning data is secu
+            'store' => false,
+            "encrypt_reasoning_content" => true,
+            'models' => [
+                [
+                    'id' => 'gpt-5',
+                    'label' => 'OpenAI GPT 5',
+                    'streamable' => false,
+                    'reasoning_effort' => 'medium',
+                ],
+                [
+                    'id' => 'gpt-5-mini',
+                    'label' => 'OpenAI GPT 5 mini',
+                    'streamable' => false,
+                    'reasoning_effort' => 'medium',
                 ]
             ]
         ],
@@ -166,3 +193,4 @@ return [
 
     ]
 ];
+

--- a/config/model_providers.php.example
+++ b/config/model_providers.php.example
@@ -72,10 +72,11 @@ return [
             'api_key' => env('OPENAI_API_KEY', ''),
             'api_url' => 'https://api.openai.com/v1/responses',
             'ping_url' => 'https://api.openai.com/v1/models',
-            // set store := false and encrypt_reasoning_content := true to 
-            // ensure that reasoning data is secure
-            'store' => false,
-            "encrypt_reasoning_content" => true,
+            // set this to true to keep encrypted reasoning
+            // tokens as part of the conversation history
+            // reasoning tokens are used in their encrypred variant
+            // with the store := false setting of messages
+            'keep_reasoning_tokens' => true,
             'models' => [
                 [
                     'id' => 'gpt-5',

--- a/config/model_providers.php.example
+++ b/config/model_providers.php.example
@@ -9,7 +9,7 @@ return [
     |   This Model is used by default before the user choses their
     |   desired model.
     */
-    'defaultModel' => 'gpt-5',
+    'defaultModel' => 'gpt-4o',
 
     /*
     |--------------------------------------------------------------------------
@@ -73,7 +73,7 @@ return [
             'api_url' => 'https://api.openai.com/v1/responses',
             'ping_url' => 'https://api.openai.com/v1/models',
             // set store := false and encrypt_reasoning_content := true to 
-            // ensure reasoning data is secu
+            // ensure that reasoning data is secure
             'store' => false,
             "encrypt_reasoning_content" => true,
             'models' => [

--- a/database/migrations/2025_04_04_123507_update_enum_type_on_usage_records_table.php
+++ b/database/migrations/2025_04_04_123507_update_enum_type_on_usage_records_table.php
@@ -8,7 +8,7 @@ class UpdateEnumTypeOnUsageRecordsTable extends Migration
 {
     public function up()
     {
-        // This updates the 'type' column to include 'api'.
+        /// This updates the 'type' column to include 'api'.
         DB::statement("
             ALTER TABLE `usage_records`
             MODIFY COLUMN `type` ENUM('private', 'group', 'api')

--- a/database/migrations/2025_08_31_113954_create_ai_conv_msg_auxes_table.php
+++ b/database/migrations/2025_08_31_113954_create_ai_conv_msg_auxes_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+        Schema::create('ai_conv_msg_auxes', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('msg_id')->constrained('ai_conv_msgs')->onDelete('cascade');
+            $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
+            $table->string('type');
+            $table->string('iv');
+            $table->string('tag');
+            $table->string('content');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down()
+    {
+        Schema::dropIfExists('ai_conv_msg_auxes');
+    }
+};

--- a/public/js_v2.0.1_f1/ai_chat_functions.js
+++ b/public/js_v2.0.1_f1/ai_chat_functions.js
@@ -143,11 +143,8 @@ async function buildRequestObjectForAiConv(msgAttributes, messageElement = null,
             if(!msgAttributes['broadcasting'] && msgAttributes['stream']){
                 setSendBtnStatus(SendBtnStatus.STOPPABLE);
             }
-            console.log("!!!!!");
-            console.log(data.content);
-
-            // console.log(data.content);
-            const {messageText, groundingMetadata, previousMessageId} = deconstContent(data.content);
+            
+            const {messageText, groundingMetadata, providerMessageId} = deconstContent(data.content);
             if(groundingMetadata != ""){
                 metadata = groundingMetadata;
             }
@@ -159,9 +156,7 @@ async function buildRequestObjectForAiConv(msgAttributes, messageElement = null,
             messageObj.content = content;
             messageObj.completion = data.isDone;
             messageObj.model = msgAttributes['model'];
-            messageObj.previousMessageId = previousMessageId;
-
-            console.log(messageObj);
+            messageObj.providerMessageId = providerMessageId;
 
             if (!messageElement) {
                 initializeMessageFormating()

--- a/public/js_v2.0.1_f1/ai_chat_functions.js
+++ b/public/js_v2.0.1_f1/ai_chat_functions.js
@@ -143,9 +143,11 @@ async function buildRequestObjectForAiConv(msgAttributes, messageElement = null,
             if(!msgAttributes['broadcasting'] && msgAttributes['stream']){
                 setSendBtnStatus(SendBtnStatus.STOPPABLE);
             }
+            console.log("!!!!!");
+            console.log(data.content);
 
             // console.log(data.content);
-            const {messageText, groundingMetadata} = deconstContent(data.content);
+            const {messageText, groundingMetadata, previousMessageId} = deconstContent(data.content);
             if(groundingMetadata != ""){
                 metadata = groundingMetadata;
             }
@@ -157,6 +159,9 @@ async function buildRequestObjectForAiConv(msgAttributes, messageElement = null,
             messageObj.content = content;
             messageObj.completion = data.isDone;
             messageObj.model = msgAttributes['model'];
+            messageObj.previousMessageId = previousMessageId;
+
+            console.log(messageObj);
 
             if (!messageElement) {
                 initializeMessageFormating()

--- a/public/js_v2.0.1_f1/ai_chat_functions.js
+++ b/public/js_v2.0.1_f1/ai_chat_functions.js
@@ -98,6 +98,19 @@ async function sendMessageConv(inputField) {
         messageObj.iv = cryptoMsg.iv;
         messageObj.tag = cryptoMsg.tag;
 
+        // handle auxiliaries data
+        messageObj.auxiliaries = messageObj.auxiliaries ?? []
+        auxiliaries = []
+        for (const auxiliary of messageObj.auxiliaries) {
+            const cryptoMsg = await encryptWithSymKey(convKey, auxiliary.content, false);
+            auxiliaries.push({
+                content: cryptoMsg.ciphertext,
+                iv: cryptoMsg.iv,
+                tag: cryptoMsg.tag,
+                type: auxiliary.type,
+            })
+        };
+
         // Submit Message to server.
 
         const requestObj = {
@@ -107,6 +120,7 @@ async function sendMessageConv(inputField) {
             'iv': messageObj.iv,
             'tag': messageObj.tag,
             'completion': true,
+            'auxiliaries': auxiliaries
         }
         const submittedObj = await submitMessageToServer(requestObj, `/req/conv/sendMessage/${activeConv.slug}`);
         submittedObj.content = messageObj.content;
@@ -115,6 +129,7 @@ async function sendMessageConv(inputField) {
         // create and add message element to chatlog.
         const messageElement = addMessageToChatlog(submittedObj);
         messageElement.dataset.rawMsg = submittedObj.content;
+        messageElement.dataset.auxiliaries = JSON.stringify(submittedObj.auxiliaries);
         scrollToLast(true, messageElement);
     }
 
@@ -144,7 +159,7 @@ async function buildRequestObjectForAiConv(msgAttributes, messageElement = null,
                 setSendBtnStatus(SendBtnStatus.STOPPABLE);
             }
             
-            const {messageText, groundingMetadata, providerMessageId} = deconstContent(data.content);
+            const {messageText, groundingMetadata} = deconstContent(data.content);
             if(groundingMetadata != ""){
                 metadata = groundingMetadata;
             }
@@ -156,14 +171,19 @@ async function buildRequestObjectForAiConv(msgAttributes, messageElement = null,
             messageObj.content = content;
             messageObj.completion = data.isDone;
             messageObj.model = msgAttributes['model'];
-            messageObj.providerMessageId = providerMessageId;
+            messageObj.auxiliaries = data.auxiliaries;
 
             if (!messageElement) {
                 initializeMessageFormating()
                 messageElement = addMessageToChatlog(messageObj, false);
             }
             messageElement.dataset.rawMsg = msg;
+<<<<<<< HEAD
 
+=======
+            messageElement.dataset.auxiliaries = JSON.stringify(messageObj.auxiliaries);
+    
+>>>>>>> df1a51c (Refactor so that tokens are kept encrypted in the database and can be reused)
             const msgTxtElement = messageElement.querySelector(".message-text");
 
             msgTxtElement.innerHTML = formatChunk(content, groundingMetadata);
@@ -206,6 +226,24 @@ async function buildRequestObjectForAiConv(msgAttributes, messageElement = null,
             messageObj.iv = cryptoMsg.iv;
             messageObj.tag = cryptoMsg.tag;
 
+            // handle auxiliaries data
+            messageObj.auxiliaries = messageObj.auxiliaries ?? []
+            auxiliaries = []
+            for (const auxiliary of messageObj.auxiliaries) {
+                const cryptoMsg = await encryptWithSymKey(convKey, auxiliary.content, false);
+                aux = {
+                    content: cryptoMsg.ciphertext,
+                    iv: cryptoMsg.iv,
+                    tag: cryptoMsg.tag,
+                    type: auxiliary.type,
+                    
+                };
+                if (isUpdate) {
+                    aux.id = auxiliary.id;
+                }
+                auxiliaries.push(aux);
+            };
+            
             activateMessageControls(messageElement);
 
             const requestObj = {
@@ -214,7 +252,8 @@ async function buildRequestObjectForAiConv(msgAttributes, messageElement = null,
                 'iv': messageObj.iv,
                 'tag': messageObj.tag,
                 'model': messageObj.model,
-                'completion': messageObj.completion
+                'completion': messageObj.completion,
+                'auxiliaries': auxiliaries
             }
 
             if(isUpdate){
@@ -228,6 +267,7 @@ async function buildRequestObjectForAiConv(msgAttributes, messageElement = null,
 
                 submittedObj.content = cryptoContent;
                 messageElement.dataset.rawMsg = msg;
+                messageElement.dataset.auxiliaries = JSON.stringify(submittedObj.auxiliaries);
                 // messageElement.dataset.groundingMetadata = metadata;
                 addGoogleRenderedContent(messageElement, metadata);
                 updateMessageElement(messageElement, submittedObj);
@@ -284,6 +324,18 @@ async function initNewConv(messageObj){
     messageObj.iv = contData.iv;
     messageObj.tag = contData.tag;
 
+    messageObj.auxiliaries = messageObj.auxiliaries ?? []
+    auxiliaries = []
+    for (const auxiliary of messageObj.auxiliaries) {
+        const cryptoMsg = await encryptWithSymKey(convKey, auxiliary.content, false);
+        auxiliaries.push({
+            content: cryptoMsg.ciphertext,
+            iv: cryptoMsg.iv,
+            tag: cryptoMsg.tag,
+            type: auxiliary.type,
+        })
+    };
+
     //submit message to server
     const requestObj = {
         'isAi': false,
@@ -292,6 +344,7 @@ async function initNewConv(messageObj){
         'iv': messageObj.iv,
         'tag': messageObj.tag,
         'completion': true,
+        'auxiliaries': auxiliaries,
     }
     const submittedObj = await submitMessageToServer(requestObj, `/req/conv/sendMessage/${activeConv.slug}`);
 
@@ -300,6 +353,7 @@ async function initNewConv(messageObj){
     submittedObj.content = messageObj.content;
     // messageObj.content is still not processed. it equals the rawData.
     messageElement.dataset.rawMsg = submittedObj.content;
+    messageElement.dataset.auxiliaries = JSON.stringify(submittedObj.auxiliaries);
 
     // set the unassigned attirbutes to the temporarily made message Element.
     updateMessageElement(messageElement, submittedObj);
@@ -486,7 +540,14 @@ async function loadConv(btn=null, slug=null){
         const decryptedContent =  await decryptWithSymKey(convKey, msg.content, msg.iv, msg.tag);
         msg.content = decryptedContent;
         // console.log(msg.content);
+        const auxiliaries = msg.auxiliaries ?? []
+        for (const aux of auxiliaries) {
+            const decryptedContent =  await decryptWithSymKey(convKey, aux.content, aux.iv, aux.tag);
+            aux.content = decryptedContent;
+        }
     };
+
+    
 
     if(msgs.length > 0){
         chatlogElement.classList.remove('start-state');
@@ -494,7 +555,6 @@ async function loadConv(btn=null, slug=null){
     else{
         chatlogElement.classList.add('start-state');
     }
-
     loadMessagesOnGUI(convData.messages);
     scrollToLast(true);
 }

--- a/public/js_v2.0.1_f1/ai_chat_functions.js
+++ b/public/js_v2.0.1_f1/ai_chat_functions.js
@@ -178,12 +178,8 @@ async function buildRequestObjectForAiConv(msgAttributes, messageElement = null,
                 messageElement = addMessageToChatlog(messageObj, false);
             }
             messageElement.dataset.rawMsg = msg;
-<<<<<<< HEAD
-
-=======
             messageElement.dataset.auxiliaries = JSON.stringify(messageObj.auxiliaries);
     
->>>>>>> df1a51c (Refactor so that tokens are kept encrypted in the database and can be reused)
             const msgTxtElement = messageElement.querySelector(".message-text");
 
             msgTxtElement.innerHTML = formatChunk(content, groundingMetadata);

--- a/public/js_v2.0.1_f1/message_functions.js
+++ b/public/js_v2.0.1_f1/message_functions.js
@@ -1,7 +1,7 @@
 
 function addMessageToChatlog(messageObj, isFromServer = false){
 
-    const {messageText, groundingMetadata, providerMessageId} = deconstContent(messageObj.content);
+    const {messageText, groundingMetadata} = deconstContent(messageObj.content);
 
     /// CLONE
     // clone message element
@@ -26,10 +26,11 @@ function addMessageToChatlog(messageObj, isFromServer = false){
     }
 
     // allows e.g. gpt-5 to keep track of previous reasoning
-    if(messageObj.providerMessageId) {
-        messageElement.dataset.providerMessageId = messageObj.providerMessageId;
+    //console.log(messageObj.auxiliaries);
+    if(messageObj.auxiliaries) {
+        messageElement.dataset.auxiliaries = JSON.stringify(messageObj.auxiliaries);
     } else {
-        messageElement.dataset.providerMessageId = '';
+        messageElement.dataset.auxiliaries = '';
     }
 
     /// CLASSES & AVATARS
@@ -242,11 +243,11 @@ function updateMessageElement(messageElement, messageObj, updateContent = false)
     const msgTxtElement = messageElement.querySelector(".message-text");
 
     if(updateContent){
-        const {messageText, groundingMetadata, providerMessageId} = deconstContent(messageObj.content);
+        const {messageText, groundingMetadata} = deconstContent(messageObj.content);
 
         const filteredContent = detectMentioning(messageText);
         messageElement.dataset.rawMsg = messageText;
-        messageElement.dataset.providerMessageId = providerMessageId;
+        messageElement.dataset.auxiliaries = JSON.stringify(messageObj.auxiliaries);
         // messageElement.dataset.groundingMetadata = JSON.stringify(groundingMetadata);
     
 
@@ -367,15 +368,11 @@ function setDateSpan(activeThread, msgDate, formatDay = true){
 function deconstContent(inputContent){
     let messageText = '';
     let groundingMetadata = '';
-    let providerMessageId = '';
-
+    
     if(isValidJson(inputContent)){
         const json = JSON.parse(inputContent);
         if(json.hasOwnProperty('groundingMetadata')){
             groundingMetadata = json.groundingMetadata
-        }
-        if(json.hasOwnProperty('providerMessageId')){
-            providerMessageId = json.providerMessageId
         }
         if(json.hasOwnProperty('text')){
             messageText = json.text;
@@ -389,9 +386,6 @@ function deconstContent(inputContent){
         if(inputContent.text){
             messageText = inputContent.text;
         }
-        if(inputContent.providerMessageId){
-            providerMessageId = inputContent.providerMessageId;
-        }
         else{
             messageText = inputContent;
         }
@@ -400,7 +394,6 @@ function deconstContent(inputContent){
     return {
         messageText: messageText,
         groundingMetadata: groundingMetadata,
-        providerMessageId: providerMessageId
     }
 
 }

--- a/public/js_v2.0.1_f1/message_functions.js
+++ b/public/js_v2.0.1_f1/message_functions.js
@@ -1,7 +1,7 @@
 
 function addMessageToChatlog(messageObj, isFromServer = false){
 
-    const {messageText, groundingMetadata, previousMessageId} = deconstContent(messageObj.content);
+    const {messageText, groundingMetadata, providerMessageId} = deconstContent(messageObj.content);
 
     /// CLONE
     // clone message element
@@ -26,10 +26,10 @@ function addMessageToChatlog(messageObj, isFromServer = false){
     }
 
     // allows e.g. gpt-5 to keep track of previous reasoning
-    if(messageObj.previousMessageId) {
-        messageElement.dataset.previousMessageId = messageObj.previousMessageId;
+    if(messageObj.providerMessageId) {
+        messageElement.dataset.providerMessageId = messageObj.providerMessageId;
     } else {
-        messageElement.dataset.previousMessageId = '';
+        messageElement.dataset.providerMessageId = '';
     }
 
     /// CLASSES & AVATARS
@@ -242,11 +242,11 @@ function updateMessageElement(messageElement, messageObj, updateContent = false)
     const msgTxtElement = messageElement.querySelector(".message-text");
 
     if(updateContent){
-        const {messageText, groundingMetadata, previousMessageId} = deconstContent(messageObj.content);
+        const {messageText, groundingMetadata, providerMessageId} = deconstContent(messageObj.content);
 
         const filteredContent = detectMentioning(messageText);
         messageElement.dataset.rawMsg = messageText;
-        messageElement.dataset.previousMessageId = previousMessageId;
+        messageElement.dataset.providerMessageId = providerMessageId;
         // messageElement.dataset.groundingMetadata = JSON.stringify(groundingMetadata);
     
 
@@ -367,15 +367,15 @@ function setDateSpan(activeThread, msgDate, formatDay = true){
 function deconstContent(inputContent){
     let messageText = '';
     let groundingMetadata = '';
-    let previousMessageId = '';
+    let providerMessageId = '';
 
     if(isValidJson(inputContent)){
         const json = JSON.parse(inputContent);
         if(json.hasOwnProperty('groundingMetadata')){
             groundingMetadata = json.groundingMetadata
         }
-        if(json.hasOwnProperty('previousMessageId')){
-            previousMessageId = json.previousMessageId
+        if(json.hasOwnProperty('providerMessageId')){
+            providerMessageId = json.providerMessageId
         }
         if(json.hasOwnProperty('text')){
             messageText = json.text;
@@ -389,8 +389,8 @@ function deconstContent(inputContent){
         if(inputContent.text){
             messageText = inputContent.text;
         }
-        if(inputContent.previousMessageId){
-            previousMessageId = inputContent.previousMessageId;
+        if(inputContent.providerMessageId){
+            providerMessageId = inputContent.providerMessageId;
         }
         else{
             messageText = inputContent;
@@ -400,7 +400,7 @@ function deconstContent(inputContent){
     return {
         messageText: messageText,
         groundingMetadata: groundingMetadata,
-        previousMessageId: previousMessageId
+        providerMessageId: providerMessageId
     }
 
 }

--- a/public/js_v2.0.1_f1/stream_functions.js
+++ b/public/js_v2.0.1_f1/stream_functions.js
@@ -204,12 +204,22 @@ function createMsgObject(msg){
     // ToDo: insert search results
     // I'm not sure if the data from processStream() lands before getting plotted
     const filteredText = detectMentioning(msgTxt).filteredText;
+
+    auxiliaries =  msg.dataset.auxiliaries ? JSON.parse(msg.dataset.auxiliaries) : [];
+    // strip off items we don't need.
+    filteredAux = [];
+    for (aux of auxiliaries) {
+        filteredAux.push({
+            type: aux.type,
+            content: aux.content,
+        });
+    }
     messageObject = {
         role: role,
-        content:{
+        content: {
             text: filteredText,
-            providerMessageId: msg.dataset.providerMessageId
-        }
+        },
+        auxiliaries: filteredAux,
     }
     return messageObject;
 }

--- a/public/js_v2.0.1_f1/stream_functions.js
+++ b/public/js_v2.0.1_f1/stream_functions.js
@@ -204,11 +204,11 @@ function createMsgObject(msg){
     // ToDo: insert search results
     // I'm not sure if the data from processStream() lands before getting plotted
     const filteredText = detectMentioning(msgTxt).filteredText;
-
     messageObject = {
         role: role,
         content:{
             text: filteredText,
+            previousMessageId: msg.dataset.previousMessageId
         }
     }
     return messageObject;

--- a/public/js_v2.0.1_f1/stream_functions.js
+++ b/public/js_v2.0.1_f1/stream_functions.js
@@ -208,7 +208,7 @@ function createMsgObject(msg){
         role: role,
         content:{
             text: filteredText,
-            previousMessageId: msg.dataset.previousMessageId
+            providerMessageId: msg.dataset.providerMessageId
         }
     }
     return messageObject;


### PR DESCRIPTION
This PR implements the responses API from OpenAI which is better suited for GPT-5 (it seems). I went ahead and did this in a generic way, so that auxiliary items can be easily passed (and retained) for inference requests. That part wil l be useful for image generation too...

Auxiliaries are encrypted in the same way the content is, i.e. client side, and thus need an `iv` and `tag` field in the database to be decrypted. They further have `type`s so that each model provider implementation can choose what to do with them, and which one's to skip.