### PR TITLE
Set the model to the default for new conversations

### DIFF
--- a/public/js_v2.0.1_f1/ai_chat_functions.js
+++ b/public/js_v2.0.1_f1/ai_chat_functions.js
@@ -548,6 +548,7 @@ async function initNewConv(messageObj){
 function startNewChat(){
     chatlogElement.classList.add('start-state');
     clearChatlog();
+    setModel(defaultModel);
     history.replaceState(null, '', `/chat`);
 
     const systemPromptFields = document.querySelectorAll('.system_prompt_field');

--- a/public/js_v2.0.1_f1/chatlog_functions.js
+++ b/public/js_v2.0.1_f1/chatlog_functions.js
@@ -236,7 +236,7 @@ function loadMessagesOnGUI(messages) {
     // set the model in the current conversation
     // as the one used in the last message
     let lastMessage = messages.at(-1);
-    setModel(lastMessage.model);
+    if (lastMessage && lastMessage.model) { setModel(lastMessage.model); }
 }
 
 

--- a/public/js_v2.0.1_f1/chatlog_functions.js
+++ b/public/js_v2.0.1_f1/chatlog_functions.js
@@ -232,6 +232,11 @@ function loadMessagesOnGUI(messages) {
     threads.forEach(thread => {
         checkThreadUnreadMessages(thread);
     });
+
+    // set the model in the current conversation
+    // as the one used in the last message
+    let lastMessage = messages.at(-1);
+    setModel(lastMessage.model);
 }
 
 


### PR DESCRIPTION
I noticed the last model used by the user is stored in the browser's localStorage and re-used for new conversations.
Here I propose to set it to the default model for any new conversation, while at the same time keep it consistent with the last used model in past conversations.