### PR TITLE
Fixes to some labels

### DIFF
--- a/resources/language/de_DE.json
+++ b/resources/language/de_DE.json
@@ -11,7 +11,7 @@
     "Yesterday": "Gestern",
 
     "Cnf_H_Confirm": "Bestätigen",
-    "Cnf_H_Warning": "Achtung",
+    "Cnf_H_Warning": "Achtung!",
     "Cnf_H_Error": "Fehler!",
     "Cnf_H_Info": "Info:",
 

--- a/resources/language/en_US.json
+++ b/resources/language/en_US.json
@@ -12,7 +12,7 @@
     "Yesterday": "Yesterday",
 
     "Cnf_H_Confirm": "Confirm",
-    "Cnf_H_Warning": "Warning",
+    "Cnf_H_Warning": "Warning!",
     "Cnf_H_Error": "Error!",
     "Cnf_H_Info": "Info:",
 
@@ -31,7 +31,7 @@
     "Exp_Title":"SESSION TIMEOUT",
     "Exp_MSG":"Please login again!",
 
-    "Summery": "Summery",
+    "Summery": "Summary",
     "Auto_Generated":"generated automatically",
     "Exported_At":"Exported from HAWKI on:",
     "By":"by",

--- a/resources/views/partials/home/modals/confirm-modal.blade.php
+++ b/resources/views/partials/home/modals/confirm-modal.blade.php
@@ -27,7 +27,7 @@
 
     const ModalType = {
         CONFIRM: { header: 'Confirm' },
-        WARNING: { header: 'Warning!' },
+        WARNING: { header: 'Warning' },
         ERROR: { header: 'Error' },
         INFO: { header: 'Info' },
     };


### PR DESCRIPTION
Minor fixes to some labels (in particular this fixes the 'undefined' message title upon chat deletion confirmation)
Maybe I should also fix the name of the "Summery" label and not just the content, unless we want to keep a warm and sunny idea of summary :)