### PR TITLE
Fix: don't trim content

### DIFF
--- a/app/Services/AI/Providers/OpenAIResponsesProvider.php
+++ b/app/Services/AI/Providers/OpenAIResponsesProvider.php
@@ -413,7 +413,7 @@ class OpenAIResponsesProvider extends BaseAIModelProvider
             'isDone' => $isDone,
             'usage' => $usage,
             'auxiliaries' => [],
-            'skip' => trim($content) === "" && empty($imageData) && !$isDone && !$isFirstUpdate && empty($thinking_updates),
+            'skip' => ($content === '') && empty($imageData) && !$isDone && !$isFirstUpdate && empty($thinking_updates),
         ];
         
         

--- a/app/Services/AI/Providers/OpenAIResponsesProvider.php
+++ b/app/Services/AI/Providers/OpenAIResponsesProvider.php
@@ -413,7 +413,7 @@ class OpenAIResponsesProvider extends BaseAIModelProvider
             'isDone' => $isDone,
             'usage' => $usage,
             'auxiliaries' => [],
-            'skip' => ($content === '') && empty($imageData) && !$isDone && !$isFirstUpdate && empty($thinking_updates),
+            'skip' => empty($content) && $content != "0" && empty($imageData) && !$isDone && !$isFirstUpdate && empty($thinking_updates),
         ];
         
         


### PR DESCRIPTION
It looks that trimming the response content wasn't a good idea (introduced in #21 ), it messes up with the formatting.