### PR TITLE
disable usage:summarize-monthly command

### DIFF
--- a/app/Console/Commands/MonthlyUsageSummary.php
+++ b/app/Console/Commands/MonthlyUsageSummary.php
@@ -27,8 +27,8 @@ class MonthlyUsageSummary extends Command
      */
     public function handle()
     {
-        $service = new UsageAnalyzerService();
-        $service->summarizeAndCleanup();
+        //$service = new UsageAnalyzerService();
+        //$service->summarizeAndCleanup();
         
     }
 }


### PR DESCRIPTION
disable usage:summarize-monthly command because it does nothing but deop last month usage data