### PR TITLE
Add feature to allow conversation title editing

### DIFF
--- a/app/Http/Controllers/AiConvController.php
+++ b/app/Http/Controllers/AiConvController.php
@@ -120,6 +120,34 @@ class AiConvController extends Controller
         return response()->json(['success' => true, 'message' => 'Conv deleted successfully']);
     }
 
+
+    public function editConvTitle(Request $request, $slug){
+        $user = Auth::user();
+        $conv = AiConv::where('slug', $slug)->firstOrFail();
+
+        // Check if the conv exists
+        if (!$conv) {
+            return response()->json(['success' => false, 'message' => 'Conv not found'], 404);
+        }
+
+        // Check if the user is an admin of the conv
+        if ($conv->user_id != $user->id) {
+            return response()->json(['success' => false, 'message' => 'Unauthorized'], 403);
+        }
+
+        $validatedData = $request->validate([
+            'conv_name' => 'string|max:255'
+        ]);
+
+        $conv->update(['conv_name' => $validatedData['conv_name']]);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Title updated successfully',
+        ]);
+
+    }
+
     public function getUserConvs(Request $request)
     {
         // Assuming the user is authenticated

--- a/app/Http/Controllers/AiConvController.php
+++ b/app/Http/Controllers/AiConvController.php
@@ -127,7 +127,7 @@ class AiConvController extends Controller
 
         // Check if the conv exists
         if (!$conv) {
-            return response()->json(['success' => false, 'message' => 'Conv not found'], 404);
+            return response()->json(['success' => false, 'message' => 'Conversation not found'], 404);
         }
 
         // Check if the user is the owner of the conv

--- a/app/Http/Controllers/AiConvController.php
+++ b/app/Http/Controllers/AiConvController.php
@@ -130,7 +130,7 @@ class AiConvController extends Controller
             return response()->json(['success' => false, 'message' => 'Conv not found'], 404);
         }
 
-        // Check if the user is an admin of the conv
+        // Check if the user is the owner of the conv
         if ($conv->user_id != $user->id) {
             return response()->json(['success' => false, 'message' => 'Unauthorized'], 403);
         }

--- a/app/Http/Controllers/AiConvController.php
+++ b/app/Http/Controllers/AiConvController.php
@@ -123,7 +123,7 @@ class AiConvController extends Controller
 
     public function editConvTitle(Request $request, $slug){
         $user = Auth::user();
-        $conv = AiConv::where('slug', $slug)->firstOrFail();
+        $conv = AiConv::where('slug', $slug)->first();
 
         // Check if the conv exists
         if (!$conv) {
@@ -131,7 +131,7 @@ class AiConvController extends Controller
         }
 
         // Check if the user is the owner of the conv
-        if ($conv->user_id != $user->id) {
+        if (!$user || $conv->user_id != $user->id) {
             return response()->json(['success' => false, 'message' => 'Unauthorized'], 403);
         }
 

--- a/public/js_v2.0.1_f1/ai_chat_functions.js
+++ b/public/js_v2.0.1_f1/ai_chat_functions.js
@@ -852,7 +852,7 @@ async function editConvTitle() {
     const messageHTML = `
     <div>
         <p>${translation.PleaseEnterTitle}:</p>
-        <input type="text" style="width: 90%" id="modal-input" value="${currentTitle}" />
+        <input type="text" style="width: 90%" id="modal-input" value="${currentTitle}" maxlength="255"/>
     </div>
     `;
 

--- a/public/js_v2.0.1_f1/ai_chat_functions.js
+++ b/public/js_v2.0.1_f1/ai_chat_functions.js
@@ -836,4 +836,55 @@ async function requestDeleteConv() {
     }
 }
 
+
+async function editConvTitle() {
+
+    const listItem = document.querySelector(`.selection-item[slug="${activeConv.slug}"]`);
+    const titleElement = listItem.querySelector('.label.singleLineTextarea');
+    let currentTitle;
+
+    if (titleElement) {
+        currentTitle = titleElement.innerText; // Fetch the current title
+    } else {
+        return;
+    }
+
+    const messageHTML = `
+    <div>
+        <p>${translation.PleaseEnterTitle}:</p>
+        <input type="text" style="width: 90%" id="modal-input" value="${currentTitle}" />
+    </div>
+    `;
+
+    const confirmed = await openModal(ModalType.CONFIRM, messageHTML, translation.EditTitle);
+    if (!confirmed) {
+        return;
+    }
+
+    const url = `/req/conv/editConvTitle/${activeConv.slug}`;
+    const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+    const newTitle = document.getElementById("modal-input").value; 
+
+    try {
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': csrfToken
+            },
+            body: JSON.stringify({ conv_name: newTitle })
+        });
+        const data = await response.json();
+
+        if (data.success) {
+            titleElement.innerText = newTitle;
+        } else {
+            console.error('Conv title edit was not successful!');
+        }
+    } catch (error) {
+        console.error(error);
+        console.error('Failed to rename conv!');
+    }
+}
+
 //#endregion

--- a/resources/language/de_DE.json
+++ b/resources/language/de_DE.json
@@ -62,6 +62,8 @@
     "DataProtection": "Datenschutz",
     "Delete": "Löschen",
     "DeleteChat": "Chat Löschen",
+    "EditTitle": "Titel Bearbeiten",
+    "PleaseEnterTitle": "Bitte geben Sie den neuen Titel ein",
     "Description": "Beschreibung",
     "Download": "herunterladen",
     "Export": "Exportieren",

--- a/resources/language/en_US.json
+++ b/resources/language/en_US.json
@@ -64,6 +64,8 @@
     "DataProtection": "Data Protection",
     "Delete": "Delete",
     "DeleteChat": "Delete Chat",
+    "EditTitle": "Edit Title",
+    "PleaseEnterTitle": "Please enter the new title",
     "Description": "Description",
     "Download": "download",
     "Export": "Export",

--- a/resources/views/partials/home/templates.blade.php
+++ b/resources/views/partials/home/templates.blade.php
@@ -11,6 +11,7 @@
 
 		@if($activeModule === 'chat')
 			<button class="burger-item red-text" onclick="requestDeleteConv()">{{ $translation["DeleteChat"] }}</button>
+			<button class="burger-item" onclick="editConvTitle()">{{ $translation["EditTitle"] }}</button>
 		@elseif($activeModule === 'groupchat')
 			<button class="burger-item red-text" onclick="leaveRoom()">{{ $translation["LeaveRoom"] }}</button>
 		@endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -68,8 +68,8 @@ Route::middleware('prevent_back')->group(function () {
         Route::post('/req/conv/updateMessage/{slug}', [AiConvController::class, 'updateMessage']);
         Route::post('/req/conv/updateInfo/{slug}', [AiConvController::class, 'updateInfo']);
         Route::delete('/req/conv/removeConv/{slug}', [AiConvController::class, 'removeConv']);
-    
-    
+        Route::post('/req/conv/editConvTitle/{slug}', [AiConvController::class, 'editConvTitle']);
+        
         // GROUPCHAT ROUTES
         Route::get('/groupchat', [HomeController::class, 'show']);
         Route::get('/groupchat/{slug?}', [HomeController::class, 'show']);


### PR DESCRIPTION
@ilyadrv @steffenhauf 
This change allows for title editing (still without encryption: that would require some tweaks in the database and a mechanism to handle past unencrypted conversation titles).
I just reused the modal dialog available in HAWKI. Maybe not the best, but better than implementing a completely new dialog from scratch.

I am not able to produce so nice GIFs as Steffen on my linux box :(

![edit_titles](https://github.com/user-attachments/assets/c49c4493-63f6-421a-9d0b-e954dac7d1a7)
