### PR TITLE
Fix/local service model

### DIFF
--- a/config/model_providers_xfel.php.example
+++ b/config/model_providers_xfel.php.example
@@ -40,8 +40,6 @@ return [
                     ->description('Service model for title_generator, prompt_improver, summarizer')
                     ->set('streamable', true) //must be true
                     ->set('visible', false)
-                    ->set('unsafe_ssl', true)
-                    //->set('unsafe_ssl_host', true)
                     ->get(),
                 
                 //============================== normal models            
@@ -95,8 +93,11 @@ return [
                     ->description('Service model for title_generator, prompt_improver, summarizer')
                     ->set('streamable', true) //must be true
                     ->set('visible', false)
+                    ->set('unsafe_ssl', true)
+                    //->set('unsafe_ssl_host', true)
                     ->get(),            
             
+                //============================== normal models 
                 \App\Models\ModelConfiguration::abstractModel('xfel-internal-ollama-gpt-oss', 'gpt-oss-on-premise')
                     ->separator()
                     ->description('gpt OSS model host on-premise, comparable to gpt-4o-mini, and useful for summarizing sensitive information')

--- a/config/model_providers_xfel.php.example
+++ b/config/model_providers_xfel.php.example
@@ -18,9 +18,9 @@ return [
     'default_image_quota' => 10, //images per month; comment out for unlimited
     
     'system_models' => [
-        'title_generator' => 'service-model',
-        'prompt_improver' => 'service-model',
-        'summarizer' => 'service-model',
+        'title_generator' => 'local-service-model',
+        'prompt_improver' => 'local-service-model',
+        'summarizer' => 'local-service-model',
     ],
     
     'providers' =>[
@@ -34,12 +34,14 @@ return [
             'streaming_time_limit' => 240,
             'time_limit' => 240,            
             'models' => [
-                //Service model - we do not want this model to use tools and streams
-                \App\Models\ModelConfiguration::abstractModel('service-model', 'Service model') //must keep Abstract 
+                //Service model - not using tools but sill sends data to the outside
+                \App\Models\ModelConfiguration::abstractModel('openai-service-model', 'OpenAI service model') //must keep Abstract 
                     ->modelName('gpt-4o-mini')
                     ->description('Service model for title_generator, prompt_improver, summarizer')
                     ->set('streamable', true) //must be true
                     ->set('visible', false)
+                    ->set('unsafe_ssl', true)
+                    //->set('unsafe_ssl_host', true)
                     ->get(),
                 
                 //============================== normal models            
@@ -87,6 +89,14 @@ return [
             'active' => true,
             'time_limit' => 240,
             'models' => [
+                //Local service model - not using tools and keep the data inside
+                \App\Models\ModelConfiguration::abstractModel('local-service-model', 'Local service model') //must keep Abstract 
+                    ->set('api_url', 'https://localhost:8889/v1/responses')
+                    ->description('Service model for title_generator, prompt_improver, summarizer')
+                    ->set('streamable', true) //must be true
+                    ->set('visible', false)
+                    ->get(),            
+            
                 \App\Models\ModelConfiguration::abstractModel('xfel-internal-ollama-gpt-oss', 'gpt-oss-on-premise')
                     ->separator()
                     ->description('gpt OSS model host on-premise, comparable to gpt-4o-mini, and useful for summarizing sensitive information')

--- a/public/js_v2.0.1_f1/ai_chat_functions.js
+++ b/public/js_v2.0.1_f1/ai_chat_functions.js
@@ -629,15 +629,9 @@ async function generateChatName(firstMessage, convItem) {
             context: "chat_name",
             messages: [
                 {
-                    role: "system",
-                    content: {
-                        text: translation.Name_Prompt
-                    }
-                },
-                {
                     role: "user",
                     content: {
-                        text: firstMessage
+                        text: translation.Name_Prompt + "\n\n" + firstMessage
                     }
                 }
             ]

--- a/public/js_v2.0.1_f1/stream_functions.js
+++ b/public/js_v2.0.1_f1/stream_functions.js
@@ -251,15 +251,9 @@ async function requestPromptImprovement(sender) {
             stream: true,
             messages: [
                 {
-                    role: "system",
-                    content: {
-                        text: translation.Improvement_Prompt
-                    },
-                },
-                {
                     role: "user",
                     content: {
-                        text: prompt
+                        text: translation.Improvement_Prompt + "\n\n" +prompt
                     }
                 }
             ]
@@ -301,15 +295,9 @@ async function requestChatlogSummery(msgs = null) {
 
     const messages = [
         {
-            role: "system",
-            content: {
-                text: translation.Summery_Prompt
-            },
-        },
-        {
             role: "user",
             content: {
-                text: JSON.stringify(msgs)
+                text: translation.Summery_Prompt + "\n\n" + JSON.stringify(msgs)
             }
         }
     ];


### PR DESCRIPTION
Use local models to generate chant titles etc because we want to avoid sending data outside when using "onsite" models for sensetive data