### PR TITLE
this allows to separate wdatabase read/write between different server…

### DIFF
--- a/.env.xfel_example
+++ b/.env.xfel_example
@@ -1,7 +1,7 @@
 #=== DB cluster
 
 #DB_CONNECTION = mysql_cluster
-# !!!!DO NOT USE 'localhost'  there because localhost enforce ockets and port settings ignored
+# !!!!DO NOT USE 'localhost'  there because localhost enforces that sockets and port settings are ignored
 #DB_WRITE_HOST=127.0.0.1
 #DB_WRITE_PORT=3306
 #DB_READ_HOST=127.0.0.1

--- a/.env.xfel_example
+++ b/.env.xfel_example
@@ -1,3 +1,15 @@
+#=== DB cluster
+
+#DB_CONNECTION = mysql_cluster
+# !!!!DO NOT USE 'localhost'  there because localhost enforce ockets and port settings ignored
+#DB_WRITE_HOST=127.0.0.1
+#DB_WRITE_PORT=3306
+#DB_READ_HOST=127.0.0.1
+#DB_READ_PORT=3307
+# enable only on DEV
+#DB_ROUTE_LOG=true  
+
+
 #======================
 #correct streaming may require special apache config
 #/etc/apache2/conf-enabled/php8.5-fpm.conf

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\ServiceProvider;
 
 use App\Http\Middleware\RegistrationAccess;
@@ -52,6 +53,17 @@ class AppServiceProvider extends ServiceProvider
     {
         if(env('PHP_ERRORS') !== null){
             error_reporting(eval('return '.env('PHP_ERRORS').' ;'));    
-        }        
+        }
+        
+        if (env('DB_ROUTE_LOG', false) && config('app.env') != 'production') {
+            DB::listen(function (\Illuminate\Database\Events\QueryExecuted $query) {
+                \Log::info('database route', [
+                    'route' => $query->readWriteType,
+                    'sql' => $query->sql,
+                    'duration_ms' => $query->time,
+                ]);
+            });
+        }
+        
     }
 }

--- a/config/database.php
+++ b/config/database.php
@@ -50,6 +50,34 @@ return [
                 PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
+        
+        'mysql_cluster' => [
+            'driver' => 'mysql',
+            'url' => env('DB_URL'),
+            'read' => [
+                'host' => [env('DB_READ_HOST')],
+                'port' => env('DB_READ_PORT', '3306'),
+            
+            ],
+            'write' => [
+                'host' => [env('DB_WRITE_HOST')],
+                'port' => env('DB_WRITE_PORT', '3306'),
+            ],
+            'sticky' => true,
+            'database' => env('DB_DATABASE', 'laravel'),
+            'username' => env('DB_USERNAME', 'root'),
+            'password' => env('DB_PASSWORD', ''),
+            'unix_socket' => env('DB_SOCKET', ''),
+            'charset' => env('DB_CHARSET', 'utf8mb4'),
+            'collation' => env('DB_COLLATION', 'utf8mb4_unicode_ci'),
+            'prefix' => '',
+            'prefix_indexes' => true,
+            'strict' => true,
+            'engine' => null,
+            'options' => extension_loaded('pdo_mysql') ? array_filter([
+                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+            ]) : [],
+        ],        
 
         'sqlite' => [
             'driver' => 'sqlite',


### PR DESCRIPTION
This allows to separate database read/write between different servers. The point is to send all writes to one server avoiding deadlocks while keep read balanced. Transactions 'begin ...  commit' are sent to write.

Actually just a configuration of the database. This is needed because of deadlocks. I keep it running for some days on the test system and if no error in the logs will merge it